### PR TITLE
Fix auth session check for new format

### DIFF
--- a/dikidi/api.py
+++ b/dikidi/api.py
@@ -34,7 +34,7 @@ class DikidiAPI:
             }
         )
         if 'callback' in response.json():
-            if 'sw.auth.complete()' in response.json()['callback']:
+            if 'sw.auth.complete' in response.json()['callback']:
                 logging.info('Auth complete')
                 return session
         raise Exception('Session not created')
@@ -77,6 +77,6 @@ class DikidiAPI:
                                                                     and record['status_id'] == '1']
         elif 'error' in records:
             if records['error'] != 0:
-                raise Exception("Code: {}. Message: {}".format(records['error']['code'], records['error']['message']))
+                raise Exception("Code: {}. Message: {}".format(records['error'], records['message']))
         else:
             raise Exception("Request execution error")

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ pytz==2020.5
 requests==2.25.1
 six==1.15.0
 tzlocal==2.1
-urllib3==1.26.2


### PR DESCRIPTION
**Summary**
This MR updates the authentication session creation logic to accommodate a change in the API response format.

**Changes**
Updated session verification to check for 'sw.auth.complete' instead of 'sw.auth.complete()'.
Ensures compatibility with the new response containing a token inside parentheses.

**Why?**
The API now returns "callback": "sw.auth.complete('token')" instead of "callback": "sw.auth.complete()". The previous check no longer worked, preventing session creation. This fix resolves the issue.

**Related Issues/Tasks**
Resolves #1 